### PR TITLE
Updates for mllaunchpad 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Git-clone https://github.com/schuderer/mllaunchpad-template into `c:\dev\code\my
 
 The following are not really needed and can be deleted:
  - `server-scripts `
- - `requirements_frozen.txt`
 
 Now that we have the project directory set up, let's get our Python development virtual environment ready:
 

--- a/build.py
+++ b/build.py
@@ -288,7 +288,7 @@ def get_model(config, config_file):
         if user_confirms("Type 'y' to (re)train model {} now, Enter to continue without training: ".format(model_name)):
             with python_interpreter() as interpreter:
                 install_reqs(interpreter, config)
-                train_cmd = [interpreter, "-m", "mllaunchpad", "-c", config_file, "-t"]
+                train_cmd = [interpreter, "-m", "mllaunchpad", "-c", config_file, "train"]
                 print(" ".join(train_cmd))
                 train_result = subprocess.Popen(train_cmd).wait()
                 if train_result != 0:

--- a/build.py
+++ b/build.py
@@ -20,7 +20,9 @@ required_config = {
         "location": {},
     },
     "model": {
-        "name": {},
+        "name": {
+            "__check__": lambda val: "model name must not contain '_'" if "_" in val else None
+        },
         "version": {},
     },
     "deploy": {
@@ -37,9 +39,7 @@ required_config = {
         },
     },
     "api": {
-        "name": {
-            "__check__": lambda val: "api name must not contain '_'" if "_" in val else None
-        },
+        "name": {},
     },
 }
 venv_location = ".venv_temp_deploy"
@@ -513,7 +513,7 @@ def main():
 
     delete_dir(build_path)
     create_dir(build_path)
-    zip_name = os.path.join(build_path, "{}_{}.zip".format(config["api"]["name"], config["model"]["version"]))
+    zip_name = os.path.join(build_path, "{}_{}.zip".format(config["model"]["name"], config["model"]["version"]))
     print("Packaging zip file {}...".format(zip_name))
     with ZipFile(zip_name, 'w') as zip_file:
         for file in files:
@@ -538,6 +538,8 @@ def main():
         zip_file.writestr(base_url_file_name, base_url)
         print("Adding file {}".format(test_url_file_name))
         test_url = config["deploy"]["test_query"]
+        if test_url.startswith("/"):
+            test_url = test_url[1:]
         if not test_url.startswith(base_url):
             test_url = base_url + test_url
         zip_file.writestr(test_url_file_name, "/" + test_url)

--- a/config_deploy.yml
+++ b/config_deploy.yml
@@ -20,14 +20,13 @@ model_store:
 
 model:
   name: IrisModel
-  version: '0.0.5'  # use semantic versioning (<breaking>.<adding>.<fix>)
+  version: '0.0.5'  # use semantic versioning (<breaking>.<adding>.<fix>), first segment will be used in url as e.g. .../v1/...
   module: app.model  # same as file name without .py
   train_options: {}
   predict_options: {}
 
 api:
   name: iris  # name of the service api
-  version: '0.0.5'  # use semantic versioning (breaking.adding.fix), first segment will be used in url as e.g. .../v1/...
   raml: api.raml
   preload_datasources: True  # Load datasources into memory before any predictions. Only makes sense with caching.
   root_path: .  # (optional) set directory where Flask should look for the directories `static` and `templates` to serve.

--- a/config_dev.yml
+++ b/config_dev.yml
@@ -1,5 +1,6 @@
-#plugins:
-#  - examples.bogusdatasource
+# Depending on your project setup, it might be smart for every developer
+# to have their own private dev configuration and .gitignore this file
+# (e.g. if different developers keep their test/dev data in different places).
 
 datasources:
   petals:

--- a/server_scripts/reload.sh
+++ b/server_scripts/reload.sh
@@ -59,7 +59,12 @@ if [ "$train" = "true" ]; then
     echo "Starting training for $name..." 1>&2
     cd $name
     source .venv/bin/activate
-    python -m mllaunchpad train
+    python -m mllaunchpad --version 2>&1 | grep "version 0"
+    if [ $? == 0 ]; then
+        python -m mllaunchpad --train
+    else
+        python -m mllaunchpad train
+    fi
     deactivate
     echo "Finished training of $name." 1>&2
 fi

--- a/server_scripts/reload.sh
+++ b/server_scripts/reload.sh
@@ -59,7 +59,7 @@ if [ "$train" = "true" ]; then
     echo "Starting training for $name..." 1>&2
     cd $name
     source .venv/bin/activate
-    python -m mllaunchpad -t
+    python -m mllaunchpad train
     deactivate
     echo "Finished training of $name." 1>&2
 fi


### PR DESCRIPTION
Preparing the template for the upcoming ML Launchpad 1.0.0 release for which a release candidate is available: https://opencollective.com/mllaunchpad/updates/sneak-peek-into-upcoming-version-1-0-0

Please note that you might have to update your requirements files with e.g. `mllaunchpad==1.0.0rc1` or, if you want to get any and all pre-releases, `mllaunchpad>=0.0.0rc1`.

You can download this pull request's latest state (including any files you want to use) by clicking on the branch `updates_for_mllp_1.0.0` (or clicking [here](https://github.com/schuderer/mllaunchpad-template/tree/updates_for_mllp_1.0.0)) and then clicking "clone or download".

Edit: commit https://github.com/schuderer/mllaunchpad-template/pull/3/commits/212e5b992c58233ff41b2e9ba9f9a9d90ae6b97f below will fix #5